### PR TITLE
Include exceptions in default ignored type

### DIFF
--- a/NetCore.AutoRegisterDi/TypeExtensions.cs
+++ b/NetCore.AutoRegisterDi/TypeExtensions.cs
@@ -21,13 +21,22 @@ namespace NetCore.AutoRegisterDi
     internal static class TypeExtensions
     {
         /// <summary>
-        /// Check if type marked by <see cref="DoNotAutoRegisterAttribute"/>
+        ///     Check if type is marked by <see cref="DoNotAutoRegisterAttribute" /> or if type is an exception and not marked with
+        ///     any <see cref="RegisterWithLifetimeAttribute" />.
         /// </summary>
         /// <param name="type">type</param>
         public static bool IsIgnoredType(this Type type)
         {
             var doNotAutoRegisterAttribute = type.GetCustomAttribute<DoNotAutoRegisterAttribute>();
-            return doNotAutoRegisterAttribute != null;
+            var isManuallyExcluded = doNotAutoRegisterAttribute != null;
+
+            if (isManuallyExcluded)
+            {
+                return true;
+            }
+
+            var isException = type.IsSubclassOf(typeof(Exception));
+            return isException && type.GetCustomAttribute<RegisterWithLifetimeAttribute>() == null;
         }
 
         /// <summary>


### PR DESCRIPTION
Exceptions are generally created in the `throw` statement, and not resolved from DI. While this can be manually excluded upon registration, I believe it should be a default behavior that can be opted out of on use-cases that allow it.